### PR TITLE
[Lote 7] guiadeheroku: atualização 2026

### DIFF
--- a/.github/ISSUE_TEMPLATE/link-quebrado.yml
+++ b/.github/ISSUE_TEMPLATE/link-quebrado.yml
@@ -1,0 +1,35 @@
+name: 🔗 Link quebrado
+description: Reporte um link que não abre, redireciona para outro lugar ou está desatualizado.
+title: "[Link quebrado]: "
+labels: ["link-quebrado"]
+body:
+  - type: input
+    id: link
+    attributes:
+      label: Link com problema
+      placeholder: "https://..."
+    validations:
+      required: true
+  - type: input
+    id: secao
+    attributes:
+      label: Seção do guia onde ele está
+      placeholder: "Ex.: 🛠️ Ferramentas"
+    validations:
+      required: true
+  - type: dropdown
+    id: problema
+    attributes:
+      label: O que acontece
+      options:
+        - Erro 404 / página não existe
+        - Redireciona para outra página
+        - Conteúdo removido ou desatualizado
+        - Outro (descreva abaixo)
+    validations:
+      required: true
+  - type: input
+    id: substituto
+    attributes:
+      label: Sugestão de substituto (opcional)
+      placeholder: "https://..."

--- a/.github/ISSUE_TEMPLATE/sugestao-de-recurso.yml
+++ b/.github/ISSUE_TEMPLATE/sugestao-de-recurso.yml
@@ -1,0 +1,55 @@
+name: 💡 Sugestão de recurso
+description: Sugira um curso, livro, canal, ferramenta, add-on, artigo ou comunidade para o guia.
+title: "[Recurso]: "
+labels: ["sugestão"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Obrigado pela sugestão! Leia os critérios em [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) antes de enviar. Só aceitamos conteúdo legal, com link funcionando.
+  - type: input
+    id: nome
+    attributes:
+      label: Nome do recurso
+      placeholder: "Ex.: Heroku Connect"
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: URL
+      placeholder: "https://..."
+    validations:
+      required: true
+  - type: dropdown
+    id: categoria
+    attributes:
+      label: Categoria
+      options:
+        - Roadmap
+        - Documentação oficial
+        - Sites e cursos para aprender Heroku
+        - Livros
+        - Canais no YouTube
+        - Ferramentas
+        - Projetos práticos e desafios
+        - IA na prática
+        - Certificações
+        - Carreira e vagas
+        - Comunidades
+    validations:
+      required: true
+  - type: textarea
+    id: porque
+    attributes:
+      label: Por que incluir?
+      description: Uma ou duas linhas sobre o que é e por que vale o clique. Diga se é gratuito ou pago.
+    validations:
+      required: true
+  - type: checkboxes
+    id: criterios
+    attributes:
+      label: Confirmação
+      options:
+        - label: O link está funcionando e o conteúdo é legal (não é material pirateado).
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## O que este PR faz
+
+<!-- Descreva a mudança em uma ou duas frases. -->
+
+## Checklist
+
+- [ ] Todo link novo foi verificado e responde HTTP 200 (`lychee --no-progress './**/*.md'` sem erros) ✅
+- [ ] Cada recurso tem descrição de 1 linha objetiva ✅
+- [ ] O conteúdo é legal (nada de material pago redistribuído) ✅
+- [ ] Nenhum recurso válido foi removido sem substituto ou justificativa ✅

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,86 @@
+
+# Código de Conduta de Colaboração
+
+## Nosso compromisso
+
+Como participantes, colaboradoras e líderes, nós nos comprometemos a fazer com que a participação em nossa comunidade seja uma experiência livre de assédio para todas as pessoas, independentemente de idade, tamanho do corpo, deficiência aparente ou não aparente, etnia, características sexuais, identidade ou expressão de gênero, nível de experiência, educação, situação sócio-econômica, nacionalidade, aparência pessoal, raça, casta, religião ou identidade e orientação sexuais.
+
+Comprometemo-nos a agir e interagir de maneiras que contribuam para uma comunidade aberta, acolhedora, diversificada, inclusiva e saudável.
+
+## Nossos padrões
+
+Exemplos de comportamentos que contribuem para criar um ambiente positivo para a nossa comunidade incluem:
+
+* Demonstrar empatia e bondade com as outras pessoas
+* Respeitar opiniões, pontos de vista e experiências contrárias
+* Dar e receber feedbacks construtivos de maneira respeitosa
+* Assumir responsabilidade, pedir desculpas às pessoas afetadas por nossos erros e aprender com a experiência
+* Focar no que é melhor não só para nós individualmente, mas para a comunidade em geral
+
+Exemplos de comportamentos inaceitáveis incluem:
+
+* Uso de linguagem ou imagens sexualizadas, bem como o assédio sexual ou de qualquer natureza
+* Comentários insultuosos/depreciativos e ataques pessoais ou políticos (Trolling)
+* Assédio público ou privado
+* Publicar informações particulares de outras pessoas, como um endereço de e-mail ou endereço físico, sem a permissão explícita delas
+* Outras condutas que são normalmente consideradas inapropriadas em um ambiente profissional
+
+## Aplicação das nossas responsabilidades
+
+A liderança da comunidade é responsável por esclarecer e aplicar nossos padrões de comportamento aceitáveis e tomará ações corretivas apropriadas e justas em resposta a qualquer comportamento que considerar impróprio, ameaçador, ofensivo ou problemático.
+
+A liderança da comunidade tem o direito e a responsabilidade de remover, editar ou rejeitar comentários, commits, códigos, edições na wiki, erros e outras contribuições que não estão alinhadas com este Código de Conduta e irá comunicar as razões por trás das decisões da moderação quando for apropriado.
+
+## Escopo
+
+Este Código de Conduta se aplica dentro de todos os espaços da comunidade e também se aplica quando uma pessoa estiver representando oficialmente a comunidade em espaços públicos. Exemplos de representação da nossa comunidade incluem usar um endereço de e-mail oficial, postar em contas oficiais de mídias sociais ou atuar como uma pessoa indicada como representante em um evento online ou offline.
+
+## Aplicação
+
+Ocorrências de comportamentos abusivos, de assédio ou que sejam inaceitáveis por qualquer outro motivo poderão ser reportadas para a liderança da comunidade, responsável pela aplicação, via contato abrindo uma issue neste repositório ou pelas redes indicadas no README. Todas as reclamações serão revisadas e investigadas imediatamente e de maneira justa.
+
+A liderança da comunidade tem a obrigação de respeitar a privacidade e a segurança de quem reportar qualquer incidente.
+
+## Diretrizes de aplicação
+
+A liderança da comunidade seguirá estas Diretrizes de Impacto na Comunidade para determinar as consequências de qualquer ação que considerar violadora deste Código de Conduta:
+
+### 1. Ação Corretiva
+
+**Impacto na comunidade**: Uso de linguagem imprópria ou outro comportamento considerado anti-profissional ou repudiado pela comunidade.
+
+**Consequência**: Aviso escrito e privado da liderança da comunidade, esclarecendo a natureza da violação e com a explicação do motivo pelo qual o comportamento era impróprio. Um pedido de desculpas público poderá ser solicitado.
+
+### 2. Advertência
+
+**Impacto na comunidade**: Violação por meio de um incidente único ou atitudes repetidas.
+
+**Consequência**: Advertência com consequências para comportamento repetido. Não poderá haver interações com as pessoas envolvidas, incluindo interações não solicitadas com as pessoas que estiverem aplicando o Código de Conduta, por um período determinado. Isto inclui evitar interações em espaços da comunidade, bem como canais externos como as mídias sociais. A violação destes termos pode levar a um banimento temporário ou permanente.
+
+### 3. Banimento Temporário
+
+**Impacto na comunidade**: Violação grave dos padrões da comunidade, incluindo a persistência do comportamento impróprio.
+
+**Consequência**: Banimento temporário de qualquer tipo de interação ou comunicação pública com a comunidade por um determinado período. Estarão proibidas as interações públicas ou privadas com as pessoas envolvidas, incluindo interações não solicitadas com as pessoas que estiverem aplicando o Código de Conduta. A violação destes termos pode resultar em um banimento permanente.
+
+### 4. Banimento Permanente
+
+**Impacto na comunidade**: Demonstrar um padrão na violação das normas da comunidade, incluindo a persistência do comportamento impróprio, assédio a uma pessoa ou agressão ou depreciação a classes de pessoas.
+
+**Consequência**: Banimento permanente de qualquer tipo de interação pública dentro da comunidade.
+
+## Atribuição
+
+Este Código de Conduta é adaptado do [Contributor Covenant][homepage], versão 2.1, disponível em [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+As Diretrizes de Impacto na Comunidade foram inspiradas pela
+[Aplicação do código de conduta Mozilla][Mozilla CoC].
+
+Para obter respostas a perguntas comuns sobre este código de conduta, veja a página de Perguntas Frequentes (FAQ) em [https://www.contributor-covenant.org/faq][FAQ]. Traduções estão disponíveis em [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Como contribuir com o Guia de Heroku
+
+Obrigado por querer melhorar este guia! Ele faz parte da rede [Guia Dev Brasil](https://github.com/arthurspk/guiadevbrasil). Toda contribuição passa por revisão.
+
+## O que você pode sugerir
+
+- **Novo recurso** (curso, livro, canal, ferramenta, add-on, comunidade, artigo): abra uma issue com o template *Sugestão de recurso* ou envie um pull request.
+- **Link quebrado ou desatualizado:** abra uma issue com o template *Link quebrado*, de preferência já com um substituto.
+- **Correção de texto** (ortografia, descrição imprecisa, categoria errada): pull request direto.
+
+## Critérios de aceitação
+
+Um recurso só entra no guia se cumprir **todos** os itens:
+
+1. **Link funcionando** — resposta HTTP 200 no momento da revisão (verificamos com [lychee](https://github.com/lycheeverse/lychee)).
+2. **Conteúdo legal** — apenas fontes oficiais ou legitimamente gratuitas. Nada de cursos pagos redistribuídos, PDFs de livros protegidos ou "drives" de terceiros.
+3. **Descrição de 1 linha** dizendo o que é e por que vale o clique. Se for pago, diga isso na própria descrição (ex.: "Curso pago da Alura").
+4. **Ordem:** dentro de cada seção, recursos em português e gratuitos vêm primeiro.
+5. **Curadoria, não acumulação:** preferimos poucos recursos excelentes a muitos duvidosos. Se o guia já cobre o assunto com algo melhor, a sugestão pode ser recusada.
+
+Formato de cada item:
+
+```markdown
+- [Nome do recurso](https://url-verificada) — 1 linha objetiva do que é e por que vale.
+```
+
+## Fluxo de pull request
+
+1. Faça um fork e crie uma branch a partir da `main` (ex.: `feat/novo-addon-observabilidade`).
+2. Edite o `README.md`.
+3. Rode a verificação de links antes de abrir o PR:
+   ```bash
+   lychee --no-progress './**/*.md'
+   ```
+4. Abra o PR preenchendo o checklist do template. Descreva o que mudou e por quê.
+5. Um mantenedor revisa; ajustes podem ser pedidos antes do merge.
+
+## Código de conduta
+
+Ao participar, você concorda com o nosso [Código de Conduta](./CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,19 +1,258 @@
 <p align="center">
   <a href="https://github.com/arthurspk/guiadevbrasil">
-    <img src="./images/guia.png" alt="Guia Extenso de Programação https://github.com/arthurspk/guiadevbrasil" width="160" height="160">
+    <img src="./images/guia.png" alt="Guia de Heroku" width="160" height="160">
   </a>
   <h1 align="center">Guia de Heroku</h1>
 </p>
 
-Guia em construção: esse repositório ainda está em fase de desenvolvimento, em breve ele será disponibilizado para que você consiga utilizar, porém no momento a equipe do Guia Dev Brasil está trabalhando nele para trazer um conteúdo de qualidade para todas as pessoas da comunidade de tecnologia.
+## :dart: O guia para alavancar a sua carreira
 
-<sub> <strong>Siga nas redes sociais para acompanhar mais novidades: </strong> <br>
+> Heroku foi a plataforma que popularizou o PaaS (Platform as a Service): `git push heroku main` e a aplicação está no ar, sem configurar servidor e sem tocar em Kubernetes. Em novembro de 2022 a empresa encerrou os planos gratuitos de dynos, Postgres e Redis — uma mudança que reorganizou o ecossistema e levou parte da comunidade para alternativas como Render, Railway e Fly.io. Mesmo assim, o Heroku segue relevante: é usado por empresas de todos os tamanhos, tem uma das documentações mais bem cuidadas do mercado e continua evoluindo dentro da Salesforce, inclusive com recursos de inferência de IA gerenciada. Este guia reúne documentação oficial, ferramentas, projetos práticos e comunidades para quem quer aprender a plataforma de verdade — sabendo exatamente o que mudou e o que ainda vale a pena.
+
+<sub> <strong>Siga nas redes sociais para acompanhar mais conteúdos: </strong> <br>
 [<img src = "https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white">](https://github.com/arthurspk)
 [<img src = "https://img.shields.io/badge/Facebook-1877F2?style=for-the-badge&logo=facebook&logoColor=white">](https://www.facebook.com/seixasqlc/)
 [<img src="https://img.shields.io/badge/linkedin-%230077B5.svg?&style=for-the-badge&logo=linkedin&logoColor=white" />](https://www.linkedin.com/in/arthurspk/)
 [<img src = "https://img.shields.io/badge/Twitter-1DA1F2?style=for-the-badge&logo=twitter&logoColor=white">](https://twitter.com/manotoquinho)
-[<img src = "https://img.shields.io/badge/instagram-%23E4405F.svg?&style=for-the-badge&logo=instagram&logoColor=white">](https://www.instagram.com/arthurspk/)
+[![Discord Badge](https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/NbMQUPjHz7)
+[<img src = "https://img.shields.io/badge/instagram-%23E4405F.svg?&style=for-the-badge&logo=instagram&logoColor=white">](https://www.instagram.com/guiadevbrasil/)
+[![Youtube Badge](https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/channel/UCzmXzz_VR0Li8-YOvWN_t3g)
 </sub>
 
-![Ferramentas e Extensões](./images/guia.jpg)
+## ⚠️ Aviso importante
 
+> Antes de tudo você pode me ajudar e colaborar, deu bastante trabalho fazer esse repositório e organizar para fazer seu estudo ou trabalho melhor, portanto você pode me ajudar das seguintes maneiras:
+
+- Me siga no [Github](https://github.com/arthurspk)
+- Acesse as redes sociais do [Guia Dev Brasil](https://linktr.ee/guiadevbrasil)
+- Mande feedbacks no [LinkedIn](https://www.linkedin.com/in/arthurspk/)
+
+## 💡 Nossa proposta
+
+> A proposta deste guia é dar uma ideia sobre o atual panorama e guiá-lo se você estiver confuso sobre qual será o seu próximo aprendizado, sem influenciar você a seguir os 'hypes' e 'trends' do momento. Acreditamos que com um maior conhecimento das diferentes estruturas e soluções disponíveis poderá escolher a ferramenta que melhor se aplica às suas demandas. E lembre-se, 'hypes' e 'trends' nem sempre são as melhores opções.
+
+## :beginner: Para quem está começando agora
+
+> Não se assuste com a quantidade de conteúdo apresentado neste guia. Acredito que quem está começando pode usá-lo não como um objetivo, mas como um apoio para os estudos. <b>Neste momento, dê enfoque no que te dá produtividade e o restante marque como <i>Ver depois</i></b>. Ao passo que seu conhecimento se torna mais amplo, a tendência é este guia fazer mais sentido e ficar fácil de ser assimilado. Bons estudos e entre em contato sempre que quiser! :punch:
+
+## 🚨 Colabore
+
+- Abra Pull Requests com atualizações
+- Discuta ideias em Issues
+- Compartilhe o repositório com a sua comunidade
+
+## 🌍 Tradução
+
+> Se você deseja acompanhar esse repositório em outro idioma que não seja o Português Brasileiro, você pode optar pelas escolhas de idiomas abaixo, você também pode colaborar com a tradução para outros idiomas e a correções de possíveis erros ortográficos, a comunidade agradece.
+
+<img src = "https://i.imgur.com/lpP9V2p.png" alt="Guia Extenso de Programação" width="16" height="15">・<b>English — </b> [Click Here](https://github.com/arthurspk/guiadeheroku)<br>
+<img src = "https://i.imgur.com/GprSvJe.png" alt="Guia Extenso de Programação" width="16" height="15">・<b>Spanish — </b> [Click Here](https://github.com/arthurspk/guiadeheroku)<br>
+<img src = "https://i.imgur.com/4DX1q8l.png" alt="Guia Extenso de Programação" width="16" height="15">・<b>Chinese — </b> [Click Here](https://github.com/arthurspk/guiadeheroku)<br>
+<img src = "https://i.imgur.com/6MnAOMg.png" alt="Guia Extenso de Programação" width="16" height="15">・<b>Hindi — </b> [Click Here](https://github.com/arthurspk/guiadeheroku)<br>
+<img src = "https://i.imgur.com/8t4zBFd.png" alt="Guia Extenso de Programação" width="16" height="15">・<b>Arabic — </b> [Click Here](https://github.com/arthurspk/guiadeheroku)<br>
+<img src = "https://i.imgur.com/iOdzTmD.png" alt="Guia Extenso de Programação" width="16" height="15">・<b>French — </b> [Click Here](https://github.com/arthurspk/guiadeheroku)<br>
+<img src = "https://i.imgur.com/PILSgAO.png" alt="Guia Extenso de Programação" width="16" height="15">・<b>Italian — </b> [Click Here](https://github.com/arthurspk/guiadeheroku)<br>
+<img src = "https://i.imgur.com/0lZOSiy.png" alt="Guia Extenso de Programação" width="16" height="15">・<b>Korean — </b> [Click Here](https://github.com/arthurspk/guiadeheroku)<br>
+<img src = "https://i.imgur.com/3S5pFlQ.png" alt="Guia Extenso de Programação" width="16" height="15">・<b>Russian — </b> [Click Here](https://github.com/arthurspk/guiadeheroku)<br>
+<img src = "https://i.imgur.com/i6DQjZa.png" alt="Guia Extenso de Programação" width="16" height="15">・<b>German — </b> [Click Here](https://github.com/arthurspk/guiadeheroku)<br>
+<img src = "https://i.imgur.com/wWRZMNK.png" alt="Guia Extenso de Programação" width="16" height="15">・<b>Japanese — </b> [Click Here](https://github.com/arthurspk/guiadeheroku)<br>
+
+## 📚 ÍNDICE
+
+[🗺️ Roadmap](#️-roadmap) <br>
+[📖 Documentação oficial](#-documentação-oficial) <br>
+[🔤 Sites e cursos para aprender Heroku](#-sites-e-cursos-para-aprender-heroku) <br>
+[📚 Livros](#-livros) <br>
+[🎥 Canais no Youtube](#-canais-no-youtube) <br>
+[🛠️ Ferramentas](#️-ferramentas) <br>
+[🧪 Projetos práticos e desafios](#-projetos-práticos-e-desafios) <br>
+[🤖 IA na prática](#-ia-na-prática) <br>
+[💼 Carreira e vagas](#-carreira-e-vagas) <br>
+[👥 Comunidades](#-comunidades) <br>
+[🎓 Certificações](#-certificações) <br>
+
+## 🗺️ Roadmap
+
+- [The Twelve-Factor App](https://12factor.net/) — Metodologia dos doze fatores, escrita por Adam Wiggins (cofundador do Heroku): os princípios de design por trás da própria plataforma e de qualquer app moderno.
+- [Changelog oficial do Heroku](https://devcenter.heroku.com/changelog) — Todas as mudanças de plataforma, add-ons, runtimes e políticas, organizadas por data — a fonte mais confiável do que está mudando agora.
+- [Heroku — Update de março de 2026](https://www.heroku.com/blog/march-2026-update/) — Balanço trimestral oficial da equipe sobre para onde a plataforma está indo dentro da Salesforce.
+- [Como o Heroku funciona (documentação oficial)](https://devcenter.heroku.com/articles/how-heroku-works) — Visão de 10.000 pés da plataforma: slugs, dynos, buildpacks, o roteador e o ciclo de vida de um deploy.
+- [Fine-Grained Access Control Now Available for All Heroku Customers](https://www.heroku.com/blog/fine-grained-access-control-now-available-all-customers/) — Anúncio oficial (agosto/2026) do novo controle de acesso granular por capacidade, substituindo os papéis fixos antigos.
+- [Leaving Heroku in 2026: Where Your App Actually Belongs](https://dev.to/dizzydes/leaving-heroku-in-2026-where-your-app-actually-belongs-2a6p) — Artigo de 2026 sobre o momento atual do ecossistema pós fim do plano gratuito: quando ainda faz sentido ficar no Heroku e quando migrar.
+
+## 📖 Documentação oficial
+
+- [Heroku Dev Center](https://devcenter.heroku.com/) — Portal central de toda a documentação oficial: guias, referências e categorias por linguagem.
+- [Deploying with Git](https://devcenter.heroku.com/articles/git) — Como o `git push heroku main` funciona por baixo dos panos: o mecanismo de deploy mais tradicional da plataforma.
+- [Configuration Variables](https://devcenter.heroku.com/articles/config-vars) — Como definir e usar variáveis de ambiente (`heroku config`) para segredos e configuração por ambiente.
+- [The Procfile](https://devcenter.heroku.com/articles/procfile) — Como declarar os processos que sua aplicação roda (web, worker, release) no arquivo `Procfile`.
+- [Dynos and the Dyno Manager](https://devcenter.heroku.com/articles/dynos) — O que é um dyno, como o gerenciador de dynos escala e reinicia processos, e os tipos disponíveis.
+- [Limits](https://devcenter.heroku.com/articles/limits) — Limites da plataforma por plano: tamanho de slug, timeout de request, conexões, e mais — leitura obrigatória antes de ir para produção.
+- [Add-ons](https://devcenter.heroku.com/articles/add-ons) — Como funcionam os add-ons (serviços de terceiros provisionados via CLI) e o modelo de cobrança deles.
+- [Managing Add-ons](https://devcenter.heroku.com/articles/managing-add-ons) — Comandos para instalar, atualizar e remover add-ons pela CLI ou pelo dashboard.
+- [Pipelines](https://devcenter.heroku.com/articles/pipelines) — Agrupe apps de desenvolvimento, staging e produção em um pipeline com promoção entre estágios.
+- [GitHub Integration](https://devcenter.heroku.com/articles/github-integration) — Deploys automáticos a cada push numa branch do GitHub, sem precisar rodar `git push heroku`.
+- [Review Apps](https://devcenter.heroku.com/articles/github-integration-review-apps) — Um app efêmero criado automaticamente para cada pull request — ótimo para revisar mudanças antes do merge.
+- [Heroku CI](https://devcenter.heroku.com/articles/heroku-ci) — Rode a suíte de testes automaticamente a cada push, integrado ao pipeline.
+- [Container Registry & Runtime](https://devcenter.heroku.com/articles/container-registry-and-runtime) — Como fazer deploy de uma imagem Docker diretamente, sem usar buildpacks.
+- [Heroku app.json Schema](https://devcenter.heroku.com/articles/app-json-schema) — O formato do `app.json`, usado para descrever apps que podem ser provisionados com um clique (Heroku Button).
+- [Metrics](https://devcenter.heroku.com/articles/metrics) — Painel nativo de métricas de aplicação: tempo de resposta, throughput, memória e erros por dyno.
+- [Multiple Environments for an App](https://devcenter.heroku.com/articles/multiple-environments) — Padrões para manter ambientes de desenvolvimento, staging e produção separados e consistentes.
+- [Logging](https://devcenter.heroku.com/articles/logging) — Como o Logplex agrega logs de dynos, add-ons e da própria plataforma, e como direcioná-los para fora.
+- [Platform API Reference](https://devcenter.heroku.com/articles/platform-api-reference) — Referência completa da API HTTP usada por quase tudo no Heroku, inclusive a própria CLI.
+- [Categoria: Reference](https://devcenter.heroku.com/categories/reference) — Índice de toda a documentação de referência técnica: API, CLI, buildpacks, dynos e mais.
+- [Heroku Connect](https://devcenter.heroku.com/articles/heroku-connect) — Sincronização de dados bidirecional entre um app Heroku e o Salesforce, sem escrever código de integração.
+- [Apache Kafka on Heroku](https://devcenter.heroku.com/categories/kafka) — Documentação do Kafka gerenciado do Heroku, para arquiteturas orientadas a eventos.
+- [Sending Email with SMTP](https://devcenter.heroku.com/articles/smtp) — Como enviar e-mail transacional a partir de um app Heroku usando um add-on de SMTP.
+
+## 🔤 Sites e cursos para aprender Heroku
+
+> Cursos e artigos para aprender Heroku em Português
+
+- [O que é Heroku? (Alura)](https://www.alura.com.br/artigos/o-que-e-heroku) — Artigo introdutório em português: o que é a plataforma, para que serve e como começar.
+- [Heroku, Vercel e outras opções de cloud como plataforma (Alura)](https://www.alura.com.br/artigos/heroku-vercel-outras-opcoes-cloud-plataforma) — Compara o Heroku com alternativas modernas de hospedagem — leitura útil justamente por causa do fim do plano gratuito em 2022.
+- [Heroku: deploy contínuo (Alura)](https://www.alura.com.br/curso-online-heroku-deploy-continuo) — Curso pago da Alura sobre publicar aplicações no Heroku com integração e deploy contínuos.
+- [Agilidade e DevOps: um dia no desenvolvimento de software (Alura)](https://www.alura.com.br/curso-online-agilidade-devops-desenvolvimento-software) — Curso pago que simula o dia a dia de build, deploy e integração contínua usando Docker, Heroku e Travis.
+- [Tag Heroku no DEV Community](https://dev.to/t/heroku) — Artigos da comunidade sobre Heroku, incluindo publicações recentes em português e inglês.
+
+> Cursos e artigos para aprender Heroku em Inglês
+
+- [Getting Started on Heroku with Node.js](https://devcenter.heroku.com/articles/getting-started-with-nodejs) — Tutorial oficial passo a passo: da instalação da CLI ao primeiro deploy de um app Node.js.
+- [Getting Started on Heroku with Python](https://devcenter.heroku.com/articles/getting-started-with-python) — Tutorial oficial equivalente para Python — cobre virtualenv, `requirements.txt` e o primeiro deploy.
+- [Getting Started on Heroku with Ruby](https://devcenter.heroku.com/articles/getting-started-with-ruby) — Tutorial oficial para Ruby (a linguagem original da plataforma), incluindo Rails.
+- [Getting Started on Heroku with Java](https://devcenter.heroku.com/articles/getting-started-with-java) — Tutorial oficial com Maven, do build ao deploy de um app Java.
+- [Getting Started on Heroku with Go](https://devcenter.heroku.com/articles/getting-started-with-go) — Tutorial oficial para Go, incluindo módulos e o buildpack específico da linguagem.
+- [Getting Started on Heroku with Laravel](https://devcenter.heroku.com/articles/getting-started-with-laravel) — Tutorial oficial para publicar um projeto Laravel (PHP) no Heroku.
+- [Heroku Deploy — How to Push a Web App to Production (freeCodeCamp)](https://www.freecodecamp.org/news/how-to-deploy-an-application-to-heroku/) — Guia gratuito e didático do freeCodeCamp cobrindo o fluxo completo de deploy via Git.
+- [How to Build and Deploy a Backend App with Express, Postgres, GitHub and Heroku (freeCodeCamp)](https://www.freecodecamp.org/news/how-to-build-a-backend-application/) — Tutorial gratuito construindo uma API do zero até o deploy com banco de dados incluso.
+- [Scheduling Jobs in a Django App Using Heroku Scheduler (freeCodeCamp)](https://www.freecodecamp.org/news/scheduling-jobs-in-a-django-application-using-heroku-scheduler-13c971a22979/) — Como agendar tarefas periódicas em uma aplicação Django hospedada no Heroku.
+- [Building a Deployment Pipeline with GitHub Actions and Heroku (freeCodeCamp)](https://www.freecodecamp.org/news/how-to-build-a-simple-deployment-pipeline-with-reuable-github-actions-and-heroku/) — Monta um pipeline de CI/CD reutilizável combinando GitHub Actions com deploy no Heroku.
+- [The Heroku Nostalgia Trap: Why Easy Deploys Aren't the Only Answer (freeCodeCamp)](https://www.freecodecamp.org/news/the-heroku-nostalgia-trap-why-easy-deploys-arent-the-only-answer/) — Artigo de 2026 sobre os prós e contras de continuar (ou não) no Heroku hoje, com contexto histórico do fim do plano gratuito.
+- [Top Heroku Alternatives for Deployment in 2026 (freeCodeCamp)](https://www.freecodecamp.org/news/top-heroku-alternatives-for-deployment/) — Comparativo de 2026 entre Heroku e alternativas como Render, Railway e Fly.io — útil para decidir onde hospedar um novo projeto.
+- [7 Heroku Alternatives Worth Considering in 2026 (dev.to)](https://dev.to/sparrowhawk705/7-heroku-alternatives-worth-considering-in-2026-4hnh) — Outro comparativo de 2026, com foco em preço e facilidade de migração a partir do Heroku.
+
+## 📚 Livros
+
+- [Heroku: Up and Running (Neil Middleton, O'Reilly)](https://www.goodreads.com/book/show/13501639-heroku) — Livro de referência sobre a plataforma, dos fundamentos ao deploy de aplicações reais. Livro pago (O'Reilly); a página do Goodreads reúne edições e onde comprar.
+
+## 🎥 Canais no Youtube
+
+- [Salesforce Developers](https://www.youtube.com/@salesforcedevs) — Canal oficial da Salesforce (dona do Heroku), com conteúdo sobre a plataforma, Heroku Connect e integrações.
+- [Rocketseat](https://www.youtube.com/@rocketseat) — Maior canal de programação do Brasil; cobre deploy e DevOps em geral, útil para contextualizar onde o Heroku se encaixa hoje.
+- [Filipe Deschamps](https://www.youtube.com/@FilipeDeschamps) — Conteúdo de fundamentos e carreira; discute hospedagem e infraestrutura para projetos pessoais e open source.
+- [Código Fonte TV](https://www.youtube.com/@codigofontetv) — Notícias e comparativos do ecossistema dev, incluindo mudanças em serviços de nuvem como o Heroku.
+- [Traversy Media](https://www.youtube.com/@TraversyMedia) — Crash courses de praticamente toda tecnologia web, com tutoriais de deploy em várias plataformas.
+- [freeCodeCamp.org](https://www.youtube.com/@freecodecamp) — Cursos completos e gratuitos; publica com frequência conteúdo comparando Heroku a alternativas modernas.
+- [Fireship](https://www.youtube.com/@Fireship) — Vídeos curtos e diretos sobre ferramentas e serviços de deploy, incluindo Heroku e concorrentes.
+
+## 🛠️ Ferramentas
+
+> CLI e deploy local
+
+- [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) — A ferramenta de linha de comando oficial: cria apps, gerencia add-ons, lê logs e faz deploy.
+- [heroku/cli (código-fonte)](https://github.com/heroku/cli) — Repositório oficial da CLI, escrita em Node.js/oclif — leia issues para ver comandos novos e bugs conhecidos.
+- [Heroku Local](https://devcenter.heroku.com/articles/heroku-local) — Rode sua aplicação localmente exatamente como ela roda no Heroku, lendo o `Procfile` e o `.env`.
+- [Foreman](https://github.com/ddollar/foreman) — Ferramenta original (criada pelo fundador do Heroku Local) para rodar apps baseados em `Procfile` em qualquer máquina.
+- [Platform API — categoria Command Line](https://devcenter.heroku.com/categories/command-line) — Todos os artigos sobre a CLI: instalação, autenticação, plugins e automação de comandos.
+- [6 Lesser-Known Heroku CLI Commands You Probably Aren't Using](https://www.heroku.com/blog/6-lesser-known-heroku-cli-commands/) — Post oficial de 2026 com comandos pouco conhecidos da CLI que aumentam a produtividade no dia a dia.
+- [Securing Heroku CLI Credentials with System Keychain Storage](https://www.heroku.com/blog/securing-heroku-cli-credentials-with-system-keychain-storage/) — Anúncio oficial de 2026: a CLI passa a guardar credenciais no keychain do sistema operacional em vez de um arquivo em texto puro.
+
+> Buildpacks
+
+- [Buildpacks (documentação oficial)](https://devcenter.heroku.com/articles/buildpacks) — Como o Heroku detecta a linguagem do seu projeto e transforma código-fonte em um slug executável.
+- [Categoria: Heroku Buildpacks](https://devcenter.heroku.com/categories/heroku-buildpacks) — Índice de toda a documentação de buildpacks, incluindo os buildpacks de terceiros mais usados.
+- [heroku/buildpacks (Cloud Native Buildpacks)](https://github.com/heroku/buildpacks) — Nova geração de buildpacks do Heroku baseada na especificação Cloud Native Buildpacks (CNB).
+- [heroku-buildpack-nodejs](https://github.com/heroku/heroku-buildpack-nodejs) — Código-fonte do buildpack oficial de Node.js — útil para entender cache de `node_modules` e detecção de versão.
+- [heroku-buildpack-python](https://github.com/heroku/heroku-buildpack-python) — Buildpack oficial de Python: `pip`, `Pipenv`, `poetry` e detecção automática do runtime.
+- [heroku-buildpack-ruby](https://github.com/heroku/heroku-buildpack-ruby) — Buildpack oficial de Ruby/Rails, o mais antigo da plataforma.
+- [heroku-buildpack-go](https://github.com/heroku/heroku-buildpack-go) — Buildpack oficial de Go, com suporte a módulos (`go.mod`).
+- [heroku-buildpack-php](https://github.com/heroku/heroku-buildpack-php) — Buildpack oficial de PHP, incluindo suporte a Composer e às extensões mais comuns.
+- [heroku-buildpack-static](https://github.com/heroku/heroku-buildpack-static) — Sirva um site estático (HTML/CSS/JS puro) no Heroku sem precisar de um servidor de aplicação.
+- [create-react-app-buildpack](https://github.com/mars/create-react-app-buildpack) — Buildpack da comunidade para publicar projetos criados com Create React App direto no Heroku.
+
+> Bancos de dados e dados gerenciados
+
+- [Heroku Postgres](https://devcenter.heroku.com/articles/heroku-postgresql) — Banco de dados PostgreSQL como serviço, com backups automáticos, réplicas e failover gerenciado.
+- [Heroku Key-Value Store (Redis)](https://devcenter.heroku.com/articles/heroku-redis) — Redis gerenciado para cache, filas e dados efêmeros, integrado ao provisionamento de add-ons.
+- [Categoria: Heroku Postgres](https://devcenter.heroku.com/categories/heroku-postgres) — Toda a documentação de Postgres gerenciado: planos, backups, forks, upgrades e monitoramento.
+- [Heroku Postgres — Planos e preços](https://devcenter.heroku.com/articles/heroku-postgres-plans) — Comparação dos planos pagos de Postgres gerenciado disponíveis hoje na plataforma.
+- [Heroku Postgres Backups](https://devcenter.heroku.com/articles/heroku-postgres-backups) — Como agendar, criar e restaurar backups do banco de dados gerenciado.
+- [Upgrading Heroku Postgres Databases](https://devcenter.heroku.com/articles/upgrading-heroku-postgres-databases) — Passo a passo para migrar entre planos ou versões do Postgres sem downtime.
+
+> Add-ons e observabilidade
+
+- [Marketplace de Add-ons (Elements)](https://elements.heroku.com/addons) — Catálogo com centenas de serviços de terceiros provisionáveis com um comando: bancos, filas, e-mail, busca, IA e mais.
+- [New Relic APM](https://elements.heroku.com/addons/newrelic) — Monitoramento de performance de aplicação (APM): tempo de resposta, gargalos e erros em produção.
+- [Papertrail](https://elements.heroku.com/addons/papertrail) — Agregador de logs em tempo real; um dos add-ons de observabilidade mais usados no Heroku.
+- [Twilio SendGrid](https://elements.heroku.com/addons/sendgrid) — Envio de e-mail transacional em escala, com API e integração via add-on.
+- [CloudAMQP](https://elements.heroku.com/addons/cloudamqp) — RabbitMQ e LavinMQ gerenciados como serviço, para filas e mensageria entre workers.
+- [Heroku Scheduler](https://devcenter.heroku.com/articles/scheduler) — Add-on oficial e gratuito para rodar tarefas a cada 10 minutos, hora ou dia, sem manter um dyno worker ligado.
+- [Background Jobs, Queueing and Long-running Tasks](https://devcenter.heroku.com/articles/background-jobs-queueing) — Padrões oficiais para processar tarefas fora do ciclo de request/response, com dynos worker.
+- [How To Set Up a Staging Environment on Heroku in 3 Easy Steps](https://www.heroku.com/blog/how-to-set-up-staging-environment-3-easy-steps/) — Guia oficial de 2026 usando pipelines para montar um ambiente de staging em poucos passos.
+- [A 15-Second Health Check for Your Heroku Connect Data Pipeline](https://www.heroku.com/blog/health-check-for-your-heroku-connect-data-pipeline/) — Post oficial de 2026 com um checklist rápido para validar se a sincronização do Heroku Connect com o Salesforce está saudável.
+
+## 🧪 Projetos práticos e desafios
+
+- [node-js-getting-started](https://github.com/heroku/nodejs-getting-started) — App de exemplo oficial em Node.js/Express pronto para clonar e fazer deploy em minutos.
+- [python-getting-started](https://github.com/heroku/python-getting-started) — App de exemplo oficial em Python/Django, incluindo configuração de banco de dados.
+- [ruby-getting-started](https://github.com/heroku/ruby-getting-started) — App de exemplo oficial em Ruby on Rails com Postgres.
+- [java-getting-started](https://github.com/heroku/java-getting-started) — App de exemplo oficial em Java/Maven, base para testar buildpacks e add-ons.
+- [php-getting-started](https://github.com/heroku/php-getting-started) — App de exemplo oficial em PHP puro, sem framework.
+- [go-getting-started](https://github.com/heroku/go-getting-started) — App de exemplo oficial em Go com módulos, pronto para deploy.
+- [Projetos com a tag heroku no GitHub](https://github.com/topics/heroku) — Milhares de projetos open source marcados com a tag `heroku` — boa fonte de inspiração e código real para estudar.
+- [How to Build and Deploy a Backend App (freeCodeCamp)](https://www.freecodecamp.org/news/how-to-build-a-backend-application/) — Projeto guiado: API com Express e Postgres do zero até o ar, em produção no Heroku.
+- [Running FFmpeg on Heroku: The Ephemeral-Filesystem Trap](https://dev.to/javidjamae/running-ffmpeg-on-heroku-the-ephemeral-filesystem-trap-and-the-fix-4i39) — Estudo de caso real (2026) sobre processar vídeo com FFmpeg respeitando o sistema de arquivos efêmero do Heroku.
+
+## 🤖 IA na prática
+
+Heroku e IA se encontram em duas frentes: usar assistentes de IA para trabalhar mais rápido na plataforma, e usar a própria plataforma para hospedar aplicações de IA.
+
+**Para aprender e trabalhar**
+- Peça para um assistente de IA **explicar um erro de build** colado direto do `heroku logs --tail` — geralmente ele identifica se é problema de buildpack, variável de ambiente ausente ou versão de runtime incompatível.
+- Peça para **gerar um `Procfile` e um `app.json`** a partir da descrição do seu projeto (linguagem, processos web/worker, add-ons necessários).
+- Use um assistente para **revisar scripts de release** (`release:` no `Procfile`) antes de rodar migrações de banco em produção.
+- Peça exemplos de **pipeline de CI/CD** combinando GitHub Actions com deploy no Heroku.
+
+**Hospedando IA no Heroku**
+- [Heroku Managed Inference and Agents](https://devcenter.heroku.com/articles/heroku-inference) — Add-on oficial do Heroku para acessar modelos de linguagem gerenciados e construir agentes direto na plataforma, sem operar GPU própria.
+- [Categoria: AI (Dev Center)](https://devcenter.heroku.com/categories/ai) — Índice oficial de toda a documentação de IA do Heroku: inferência gerenciada, agentes e integrações.
+- [Add-on Heroku Managed Inference (Elements)](https://elements.heroku.com/addons/heroku-inference) — Página do marketplace para provisionar o add-on de inferência gerenciada com um comando.
+- [GitHub Copilot](https://github.com/features/copilot) — Autocomplete e chat com IA no editor; útil para escrever `Procfile`, scripts de release e configuração de buildpacks mais rápido.
+- [Cursor](https://cursor.com/) — Editor baseado em VS Code com IA integrada ao fluxo de trabalho, incluindo terminal e deploy.
+- [Claude Code](https://code.claude.com/docs/en/overview) — Agente de código no terminal: útil para depurar logs do `heroku logs --tail`, escrever `app.json` e automatizar tarefas de deploy.
+- [Anthropic TypeScript SDK](https://github.com/anthropics/anthropic-sdk-typescript) — SDK oficial para consumir os modelos Claude a partir de um app hospedado no Heroku.
+- [OpenAI Node/TypeScript SDK](https://github.com/openai/openai-node) — SDK oficial da OpenAI, para apps Node.js que precisam chamar modelos de linguagem a partir do Heroku.
+- [Model Context Protocol — SDK TypeScript](https://github.com/modelcontextprotocol/typescript-sdk) — Crie servidores MCP para conectar dados e ferramentas do seu app Heroku a assistentes de IA.
+
+**Limites e boas práticas**
+- IA **inventa nomes de add-ons e flags de CLI** que não existem. Confirme sempre no [Dev Center](https://devcenter.heroku.com/) antes de rodar um comando em produção.
+- Não cole `config vars` com segredos reais (chaves de API, credenciais de banco) em ferramentas de IA sem saber a política de retenção de dados delas.
+- Revise custos: add-ons de IA e bancos gerenciados são cobrados por uso — peça para a IA estimar o impacto antes de provisionar algo novo.
+
+## 💼 Carreira e vagas
+
+Heroku aparece menos em vagas hoje do que em 2018–2021, mas segue como requisito em empresas que já rodam sua stack nele, e o conhecimento de PaaS/deploy que ele ensina é transferível para qualquer nuvem.
+- [Stack Overflow Developer Survey 2025](https://survey.stackoverflow.co/2025/) — Pesquisa anual sobre o mercado dev: ferramentas de deploy e nuvem mais usadas pelos profissionais.
+- [Programathor — vagas de tecnologia](https://programathor.com.br/) — Vagas de tecnologia no Brasil; útil para buscar posições que envolvem DevOps, cloud e PaaS.
+- [GeekHunter](https://www.geekhunter.com.br/) — Plataforma brasileira onde empresas fazem propostas diretas a devs, incluindo vagas de infraestrutura.
+- [Coodesh](https://coodesh.com/) — Vagas tech no Brasil com processos seletivos padronizados.
+- [Remotar](https://remotar.com.br/) — Vagas 100% remotas para profissionais brasileiros.
+- [RemoteOK](https://remoteok.com/) — Vagas remotas internacionais; filtre por 'Heroku', 'DevOps' ou 'Platform Engineer'.
+- [Tech Interview Handbook](https://www.techinterviewhandbook.org/) — Preparação completa para entrevistas técnicas, incluindo perguntas de sistemas e deploy.
+
+## 👥 Comunidades
+
+- [Heroku Help Center](https://help.heroku.com/) — Central de ajuda oficial: artigos de suporte, status de incidentes e abertura de ticket.
+- [Heroku Status](https://status.heroku.com/) — Status em tempo real da plataforma — consulte antes de reportar um problema como se fosse bug do seu app.
+- [r/heroku](https://www.reddit.com/r/heroku/) — Subreddit da comunidade Heroku, com dúvidas, comparações e relatos de migração.
+- [TabNews](https://www.tabnews.com.br/) — Comunidade brasileira de conteúdo técnico criada por Filipe Deschamps.
+- [He4rt Developers](https://heartdevs.com/) — Comunidade brasileira open source com Discord ativo e projetos reais em produção.
+- [Frontend BR — fórum](https://github.com/frontendbr/forum) — Fórum brasileiro de front-end no GitHub Discussions, com tópicos sobre deploy e hospedagem.
+- [Desenvolvedores Brasil (Discord)](https://discord.com/invite/t3vYGUuK6P) — Comunidade brasileira com dicas, cursos, mentorias e vagas.
+- [Lista de grupos de tecnologia no Telegram (TI-Brasil)](https://github.com/TI-Brasil/lista-telegram-brasil) — Diretório de grupos brasileiros no Telegram, incluindo comunidades de backend e DevOps.
+- [Rocketseat — comunidade](https://www.rocketseat.com.br/) — Uma das maiores comunidades de devs do Brasil, com Discord aberto.
+
+## 🎓 Certificações
+
+Não existe uma certificação "de Heroku" isolada — a Salesforce (dona da plataforma) mantém uma trilha de certificação de arquitetura que cobre Heroku diretamente.
+- [Salesforce Certified Heroku Architecture Designer](https://trailhead.salesforce.com/credentials/herokuarchitect) — Certificação oficial da Salesforce (dona do Heroku) para quem projeta arquiteturas de aplicação na plataforma. Certificação paga, exige exame.

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,6 @@
+# Configuração do verificador de links (https://github.com/lycheeverse/lychee)
+# Uso: lychee --no-progress './**/*.md'
+#
+# O LinkedIn responde HTTP 999 a qualquer verificador automatizado (bloqueio anti-bot),
+# mesmo com o perfil no ar. É o único domínio excluído da verificação.
+exclude = ["^https://www\\.linkedin\\.com/"]


### PR DESCRIPTION
## Relatório do agente — guiadeheroku (Lote 7)
**Status:** 🟢 concluído

### Números
- Links auditados nesta rodada: 182 (167 únicos) · quebrados encontrados: 0 (o repositório era um esqueleto "em construção", sem conteúdo curado prévio) · substituídos: 1 (Amazon.com.br bloqueava o verificador `lychee` mesmo respondendo 200 para um navegador real — trocado por Goodreads, que verifica limpo) · removidos: 0
- Recursos antes → depois: 0 → 121 (novos 2024–2026: 15)
- Categorias cobertas: 12/15 (Roadmap, Documentação oficial, Cursos/sites — PT e EN, Livros, YouTube, Ferramentas, Projetos práticos, IA na prática, Certificações, Carreira e vagas, Comunidades)
- Tradução EN: não criada — por decisão normativa (`PADRAO-LAYOUT-CORRIGIDO.md`), este repositório segue o esqueleto original dos flagships, que usa a fachada de "🌍 Tradução" (11 idiomas, self-referente) em vez de uma tradução real

### O que foi preservado do conteúdo original
- O repositório estava no estado "em construção" (README de 1.460 bytes, sem seções reais, sem sumário). Não havia recurso curado a preservar.
- `LICENSE` (MIT, 2022) mantida sem alteração.
- `images/guia.png` (logo) mantida e referenciada no cabeçalho; `images/guia.jpg` (banner do mascote) mantida no repositório mas não referenciada no README, conforme padrão dos demais guias.

### Decisões que merecem revisão humana
- **Fim do plano gratuito do Heroku (nov/2022)** foi tratado como contexto central do guia: mencionado na introdução, na seção de cursos/sites ("Heroku, Vercel e outras opções de cloud") e na de carreira. Vale conferir se o tom ("ainda relevante, mas ecossistema mudou") está alinhado com a voz editorial desejada.
- **YouTube**: não encontrei um canal oficial do Heroku no YouTube (`@heroku`, `@HerokuInc`, `@HerokuDev` retornaram 404). Usei o canal oficial da Salesforce Developers (dona do Heroku) como referência institucional, complementado por canais brasileiros generalistas de deploy/DevOps — nenhum vídeo específico de "curso de Heroku" foi encontrado com confiança suficiente para publicar sem risco de link errado ou canal incorreto, dado que a busca na web (WebSearch) esgotou o orçamento da sessão.
- **Cursos em português são escassos**: a seção PT tem 5 itens (contra 13 em inglês), refletindo a realidade de que o interesse editorial em Heroku no Brasil diminuiu bastante após 2022. Não inventei cursos que não encontrei — preferi um guia mais curto e honesto a preencher com conteúdo fraco ou desatualizado.
- **Certificação**: não existe certificação "de Heroku" isolada; usei a certificação oficial da Salesforce "Heroku Architecture Designer" (paga, com exame), que é a única certificação oficial real ligada à plataforma.
- **WebSearch esgotado** logo no início da curadoria (orçamento compartilhado da sessão). Toda a pesquisa de conteúdo foi feita com `WebFetch` (páginas de tags do dev.to, freeCodeCamp, blog oficial do Heroku, Dev Center) e conhecimento próprio, sempre com verificação HTTP 200 via `curl`/`urllib` antes de publicar qualquer link — nenhum recurso foi incluído sem essa verificação.

### Definition of Done
- [x] `lychee --no-progress './**/*.md'` finaliza **sem erros** (182 links, 0 erros, 7 redirects legítimos — Discord, Contributor Covenant, Facebook login, GeekHunter rebrand)
- [x] Estrutura segue o esqueleto canônico dos flagships (`PADRAO-LAYOUT-CORRIGIDO.md`): cabeçalho, ":dart: O guia para alavancar a sua carreira", "⚠️ Aviso importante", "💡 Nossa proposta", ":beginner: Para quem está começando agora", "🚨 Colabore", "🌍 Tradução" (fachada original), "📚 ÍNDICE", seções de conteúdo
- [x] Mínimo de categorias atingido: 12/15 · 121 recursos verificados (meta: ≥80) · 15 deles publicados/atualizados em 2024–2026 (meta: ≥15)
- [x] Seção **🤖 IA na prática** presente e específica do tema (assistentes de IA aplicados ao dia a dia do Heroku + o add-on oficial de inferência gerenciada)
- [x] Marcador "em construção" removido; fachada de idiomas mantida **exatamente** como o padrão corrigido determina (não é uma remoção — é a estrutura oficial dos flagships)
- [x] Sem `translations/README.en.md` (por decisão normativa deste lote) — N/A
- [x] `LICENSE`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` e templates de issue/PR presentes
- [x] Descrição, homepage e topics do repositório atualizados
- [x] Sumário (📚 ÍNDICE) com âncoras reais, no mesmo formato validado no canário `guiadetypescript`
- [x] Ortografia revisada; sem marcadores 🆕/💰/🇺🇸 por item (só texto, conforme padrão corrigido)
- [x] Nenhum recurso válido pré-existente removido (não havia nenhum)
- [x] Relatório final do agente no corpo do PR
